### PR TITLE
feat(treefmt, vscode): Set up treefmt for consistent formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "jnoortheen.nix-ide"
+    "jnoortheen.nix-ide",
+    "ibecker.treefmt-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "nixfmt"
   ],
   "[nix]": {
-    "editor.defaultFormatter": "jnoortheen.nix-ide",
+    "editor.defaultFormatter": "ibecker.treefmt-vscode",
     "editor.formatOnSave": true
   },
   "nix.enableLanguageServer": true,

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
           pkgs.nixfmt
           pkgs.alejandra
           pkgs.nixd
+          pkgs.prettier
+          pkgs.treefmt
           myVscode
         ];
         shellHook = ''

--- a/nix/modules/treefmt.nix
+++ b/nix/modules/treefmt.nix
@@ -1,17 +1,23 @@
 {
+  config,
   pkgs,
   ...
 }:
+let
+  treefmtConfig = "${config.home.homeDirectory}/.config/treefmt/treefmt.toml";
+in
 {
   # treefmt plus the formatters it drives. They need to be on PATH because a
   # treefmt config references them by command name.
-  #
-  # The config itself lives at treefmt/treefmt.toml in this repo and is used as
-  # a template: copy it into a project root as treefmt.toml. treefmt then
-  # discovers it by walking upward from the working directory.
   home.packages = with pkgs; [
     treefmt
     nixfmt
     prettier
   ];
+
+  home.file.".config/treefmt/treefmt.toml".source = ../../treefmt/treefmt.toml;
+
+  # Use the shared config when a project does not provide TREEFMT_CONFIG
+  # itself. Current treefmt versions still infer the tree root from Git.
+  home.sessionVariables.TREEFMT_CONFIG = treefmtConfig;
 }

--- a/nix/modules/vscode.nix
+++ b/nix/modules/vscode.nix
@@ -1,4 +1,8 @@
-{ pkgs, ... }:
+{
+  config,
+  pkgs,
+  ...
+}:
 let
   dotsDir = ../..;
   vscodeConfigDir = "Library/Application Support/Code/User";
@@ -10,6 +14,9 @@ let
     "nix.formatterPath" = [ "${pkgs.nixfmt}/bin/nixfmt" ];
     "nix.serverPath" = "${pkgs.nixd}/bin/nixd";
     "nix.serverSettings".nixd.formatting.command = [ "${pkgs.nixfmt}/bin/nixfmt" ];
+    "treefmt.command" = "${pkgs.treefmt}/bin/treefmt";
+    "treefmt.config" = "${config.home.homeDirectory}/.config/treefmt/treefmt.toml";
+    "treefmt.useStdin" = true;
   };
 in
 {
@@ -36,6 +43,7 @@ in
 
         # General formatting
         esbenp.prettier-vscode
+        ibecker.treefmt-vscode
 
         # PDF
         tomoki1207.pdf

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -1,0 +1,11 @@
+# Project-local copy of treefmt/treefmt.toml. Its presence at the workspace
+# root also activates the treefmt VS Code extension.
+
+[formatter.nixfmt]
+command = "nixfmt"
+includes = ["*.nix"]
+
+[formatter.prettier]
+command = "prettier"
+options = ["--write", "--prose-wrap", "always", "--print-width", "80"]
+includes = ["*.md"]

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -59,16 +59,14 @@
   "editor.wordWrapColumn": 80,
   "workbench.preferredLightColorTheme": "Visual Studio Light",
   "[markdown]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "prettier.printWidth": 80,
-    "prettier.proseWrap": "always"
+    "editor.defaultFormatter": "ibecker.treefmt-vscode"
   },
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
   "[nix]": {
-    "editor.defaultFormatter": "jnoortheen.nix-ide",
+    "editor.defaultFormatter": "ibecker.treefmt-vscode",
     "editor.formatOnSave": true
   },
   "nix.enableLanguageServer": true,


### PR DESCRIPTION
Introduce `treefmt` to manage code formatters like `nixfmt` and `prettier`.  Configure `nixfmt` for Nix files and `prettier` for Markdown files.  Integrate `treefmt-vscode` extension for on-save formatting in VS Code.  Centralize formatter configuration using `home-manager`.